### PR TITLE
Update Dockerfile to use version 2.51.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm-slim
 LABEL Name=prometheus-docker
 LABEL maintainer="Chris Campbell"
 
-ARG PROMETHEUS_VERSION="2.50.0"
+ARG PROMETHEUS_VERSION="2.51.0"
 
 RUN apt update && apt full-upgrade -y
 RUN apt install -y wget


### PR DESCRIPTION
Updates to the latest version of Prometheus.

https://github.com/prometheus/prometheus/releases/tag/v2.51.0

My motivation for the version upgrade is to fix this issue that I've run into on my instance: https://github.com/grafana/grafana/issues/82873